### PR TITLE
Fixed a major I2C bug

### DIFF
--- a/US_FUNCTIONS/GY521.c
+++ b/US_FUNCTIONS/GY521.c
@@ -7,36 +7,35 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-#define ADDR 0x68
+#define addr 0x68
 
 static int file;
 static __s32 res;
 static __u8 reg;
+static __u8 values[14];   //array to hold all the register values
 
-//set flag to 1 for making it sleep and 0 for awake.
 void set_sleep_gy521(int flag)
 {
-	if(flag==0)
+	if(flag==0)    //wake up the device
 	{
+		//Accessing reg 107
 		reg = 0x6B;
 		uint8_t val8 = 0x01;     //write 0x00 if you want to set the internal 8MHz oscillator as CLK                                              
 		res = i2c_smbus_write_byte_data(file, reg, val8);
 		if(res<0) 
-			perror("Failed to wake it up");
-		/*else 
+			perror("Failed to wake it up\n");
+		else 
 			printf("Device is awake\n");
-		*/
 	}
-	else if(flag == 1)    //set it to sleep
+	else      //set it to sleep
 	{
 		reg = 0x6B;
-		uint8_t val8 = 0x41;   //write 0x40 if you want to set the internal 8MHz oscillator as CLK
+		uint8_t val8 = 0x41;   //write 0x40 if you want to set the internal 8MHz oscillator as CLK                                             //
 		res = i2c_smbus_write_byte_data(file, reg, val8);
 		if(res<0) 
-			perror("Failed to go to sleep");
-		/*else 
+			perror("Failed to go to sleep\n");
+		else 
 			printf("In sleep mode\n");
-		*/
 	}
 }
 
@@ -51,9 +50,9 @@ void init_gy521()
 		perror("File not opened");	
 		exit(1);
 	}
-	if(ioctl(file, I2C_SLAVE, ADDR)<0)
+	if(ioctl(file, I2C_SLAVE, addr)<0)
 	{
-		perror("Not able to access the device");
+		perror(":( Not able to access the device\n");
 		exit(EXIT_FAILURE);
 	}
 
@@ -61,68 +60,77 @@ void init_gy521()
 
 	res = i2c_smbus_write_byte_data(file, 0x1B, 0x00);
 	if(res<0)
-		perror("Failed to set gyro range");
+		perror("Failed to set gyro range\n");
 	res = i2c_smbus_write_byte_data(file, 0x1C, 0x00);
 	if(res<0)
-		perror("Failed to set the accelerometer range");
+		perror("Failed to set the accelerometer range\n");
 
 	set_sleep_gy521(0);  //this also sets the clock source to X-axis gyro reference which is slightly better than the internal 8MHz oscillator
 }
 
+//get_values() stores all the register measurements in the array values
+
+int get_values()
+{
+	//reading all the values needed at once in a block
+	res = i2c_smbus_read_i2c_block_data(file, 0x3B, 14, (__u8*)values);     
+	if(res<0)
+		perror("Failed to read using Block");
+	return res;
+}
+
 float get_Ax()
 {
-	int16_t xout = i2c_smbus_read_byte_data(file, 0x3B); int16_t xout1 = i2c_smbus_read_byte_data(file, 0x3C);
-	xout = (xout<<8) | xout1;
-	return xout/16384.0*9.8;	//taking value of g=9.8
+	int c = get_values();      //calls get_values() to get all values at a time instant
+	int16_t xout;
+	if(c>0)
+		xout = (((int16_t)values[0])<<8) | values[1];
+	else
+	{	
+		perror("Can't get the values");
+		exit(EXIT_FAILURE); 
+	}
+	return xout/16384.0*9.8;
 }
 
 float get_Ay()
 {	
-	int16_t yout = i2c_smbus_read_byte_data(file, 0x3D); int16_t yout1 = i2c_smbus_read_byte_data(file, 0x3E);
-	yout = (yout<<8) | yout1;
+	//concatenate the higher byte and the lower byte
+	int16_t yout = (((int16_t)values[2])<<8) | values[3];
 	return yout/16384.0*9.8;
 }
 
 float get_Az()
 {
-	int16_t zout = i2c_smbus_read_byte_data(file, 0x3F); int16_t zout1 = i2c_smbus_read_byte_data(file, 0x40);
-	zout = (zout<<8) | zout1;
+	int16_t zout = (((int16_t)values[4])<<8) | values[5];
 	return zout/16384.0*9.8;
 }
 
 float get_temp()
 {
-	res = i2c_smbus_read_word_data(file, 0x41);           					//finally!
-	__s32 lsb = (res & 0x0000ff00); lsb=(lsb>>8)&0x000000ff;
-	__s32 msb = (res & 0x000000ff); msb=msb<<8;
-	__s32 temp = msb|lsb; 
-	temp=temp<<16; temp=temp>>16;
+	__s16 temp = (((int16_t)values[6])<<8) | values[7];
 	return (temp/340.0 + 36.53);	
 }
 
 float get_Wx()
 {
-	__s16 gyro_x = i2c_smbus_read_byte_data(file, 0x43); __s16 gyro_x1 = i2c_smbus_read_byte_data(file, 0x44);
-	gyro_x = (gyro_x<<8) | gyro_x1;	
-	return gyro_x/131.0;
+	__s16 xgyro = (((int16_t)values[8])<<8) | values[9]; 
+	return xgyro/131.0;
 }
-
 float get_Wy()
 {
-	__s16 gyro_y = i2c_smbus_read_byte_data(file, 0x45); __s16 gyro_y1 = i2c_smbus_read_byte_data(file, 0x46);
-	gyro_y = (gyro_y<<8) | gyro_y1;
-	return gyro_y/131.0;
+	__s16 ygyro = (((int16_t)values[10])<<8) | values[11]; 
+	return ygyro/131.0;
 }
 
 float get_Wz()
 {
-	__s16 gyro_z = i2c_smbus_read_byte_data(file, 0x47); __s16 gyro_z1 = i2c_smbus_read_byte_data(file, 0x48);
-	gyro_z = (gyro_z<<8) | gyro_z1;
-	return gyro_z/131.0;
+	__s16 zgyro = (((int16_t)values[12])<<8) | values[13]; 
+	return zgyro/131.0;
 }
 
 void clear_gy521()
-{	
+{
 	close(file);
 }
 


### PR DESCRIPTION
Added functionality to read the values from the registers in a block all at once instead of reading them byte-wise one by one. This sorts out the concurrency issue which was plaguing the code earlier.